### PR TITLE
Fixes broken tmux link

### DIFF
--- a/index.slim
+++ b/index.slim
@@ -28,7 +28,7 @@ hr
     h2 Installation
 
 
-    p tmate is a fork of <a href="http://tmux.sourceforge.net/">tmux</a>.
+    p tmate is a fork of <a href="https://tmux.github.io/">tmux</a>.
       tmate and tmux can coexist on the same system.
 
     .tabbable


### PR DESCRIPTION
http://tmux.sourceforge.net/ is returning 404
new home page for tmux project: https://tmux.github.io/